### PR TITLE
Multi-session MCP server with per-decision harvest

### DIFF
--- a/docs/mcp_server.md
+++ b/docs/mcp_server.md
@@ -1,17 +1,27 @@
 # Solitaire MCP Server
 
-The MCP server lets an agentic AI play Klondike Solitaire move by move through
-the [Model Context Protocol](https://modelcontextprotocol.io). Its defining
-feature is a configurable **information level**: when you start a game you
-decide exactly how much the agent is allowed to see.
+The MCP server lets agentic AI players play Klondike Solitaire move by move
+through the [Model Context Protocol](https://modelcontextprotocol.io). Each
+connected agent plays its own concurrent game; per-session locks keep moves
+within one game serial while allowing different sessions to make progress in
+parallel.
+
+Two defining features:
+
+1. **Configurable information level** -- choose exactly how much the agent is
+   allowed to see, from realistic human-style imperfect information to full
+   perfect-information view.
+2. **Server-side harvest emitter** -- when every move is made by an AI, the
+   server can capture one structured decision record per `play_move` call,
+   producing ingest-ready training data for distillation.
 
 ## Why an information level?
 
 Real Solitaire is a game of *imperfect information* -- you cannot see face-down
 tableau cards or the order of the stock. A solver, by contrast, plays with
 *perfect information*. The server lets you pick any point on that spectrum so
-you can study how an agent plays when it must reason under uncertainty versus
-when it can see everything.
+you can study how an agent plays under uncertainty versus when it can see
+everything.
 
 Three knobs control what is revealed:
 
@@ -51,21 +61,51 @@ client config:
 }
 ```
 
+## Multi-session model
+
+Every `new_game` call mints an opaque `session_id` (UUID4). Pass it back on
+every subsequent tool call so the server knows which game you're acting on.
+
+* The registry caps simultaneously open sessions (default 100); call
+  `end_session` to free a slot when a game ends.
+* Per-session locks mean two agents can play in parallel; calls *within* one
+  session still serialise.
+* `list_sessions` returns a live snapshot of every active session.
+
+```python
+# Pseudocode for an agent client
+result = call_tool("new_game", agent_id="alice", model="gemma-4-31b-it")
+sid = result["session_id"]
+while True:
+    legal = call_tool("get_legal_moves", session_id=sid)
+    chosen = pick_move(legal)
+    out = call_tool("play_move", session_id=sid, move_index=chosen,
+                    decision_meta={"confidence": 0.9, "reasoning": "..."})
+    if out["won"] or out["stuck"]:
+        break
+call_tool("end_session", session_id=sid)
+```
+
 ## Tools
 
 | Tool | Description |
 |------|-------------|
-| `new_game` | Deal a fresh game. Arguments: `seed`, `draw_count`, `face_down`, `stock`, `waste`, `include_legal_moves`. Returns the first observation. |
-| `get_observation` | The current observation at the configured information level. |
+| `new_game` | Deal a fresh game; returns `{session_id, agent, observation}`. Accepts `seed`, `draw_count`, info-level knobs (`face_down`, `stock`, `waste`, `include_legal_moves`), and agent identity (`agent_id`, `model`, `provider`, `app_commit`). |
+| `list_sessions` | Return a summary of every active session on this server. |
+| `end_session` | Close a session and free its slot; records `game_abandoned` if unfinished. |
+| `get_observation` | The session's current observation at its configured information level. |
 | `get_legal_moves` | The legal actions, each with a stable `index`. |
-| `play_move` | Apply the action at `move_index`; returns the result and new observation. |
+| `play_move` | Apply the action at `move_index`; emits one decision record to the harvest stream. Accepts optional `decision_meta` (`confidence`, `reasoning`, `boardAnalysis`, `alternativeMoveIndex`, `thinkingText`). |
 | `set_information_level` | Change what the agent may see mid-game. |
 | `render_board` | A compact, human-readable text board. |
 | `game_status` | Won / stuck / score / move and redeal counts. |
 | `suggest_move` | A hint from the built-in greedy strategy. |
 | `get_game_log` | The full per-game session log (see below). |
 | `save_game_log` | Write the session log to a JSON file. |
-| `get_server_analytics` | Aggregate analytics across all games this session. |
+| `get_server_analytics` | Aggregate analytics across all games + harvest stats + active session count. |
+
+Except for `new_game`, `list_sessions`, and `get_server_analytics`, every tool
+takes `session_id` as its first argument.
 
 ## Session log
 
@@ -87,15 +127,16 @@ seed can be fully reconstructed from its log.
 
 Separately from the per-game session log, the server records a **cross-game
 event stream** for detailed analysis of play across many games. Every game
-lifecycle step is recorded as a structured event:
+lifecycle step is recorded as a structured event, tagged with `session_id`:
 
-- `game_started` -- seed, draw count, information level
+- `game_started` -- session_id, seed, draw count, info level, agent metadata
 - `move` -- the action kind, description, score, and win/stuck flags
 - `game_ended` -- the result (won / stuck), score, and counters
-- `game_abandoned` -- a game replaced by `new_game` before it finished
+- `game_abandoned` -- a session ended before it finished
 
 `get_server_analytics` returns aggregates: games started/completed/won/stuck/
-abandoned, win rate, actions logged by kind, and average game length.
+abandoned, win rate, actions logged by kind, average game length, harvest
+totals, and active session count.
 
 To persist the raw event stream for offline analysis, set the
 `SOLITAIRE_MCP_LOG_FILE` environment variable to a file path -- each event is
@@ -108,13 +149,58 @@ SOLITAIRE_MCP_LOG_FILE=./solitaire_events.jsonl python -m solitaire_analytics.mc
 Events are also emitted via Python `logging` to **stderr** (stdout is reserved
 for the MCP protocol and is never written to).
 
+## Decision harvest (training data for distillation)
+
+When every move on the server is made by an AI agent -- e.g. the Gemma 4 E2B
+distillation pipeline -- the server doubles as the authoritative training-data
+source. Set `SOLITAIRE_MCP_HARVEST_FILE` to a JSONL path and every successful
+`play_move` writes one record:
+
+```bash
+SOLITAIRE_MCP_HARVEST_FILE=./data/raw/server_harvest.jsonl \
+    python -m solitaire_analytics.mcp_server
+```
+
+Each record is shaped to align with the fields
+`scripts/ingest_exports.py` derives from the external collection harness, so
+the file drops into `data/raw/` for ingestion with minimal adaptation. Fields:
+
+| Field | Source |
+|---|---|
+| `id` | UUID4, fresh per decision |
+| `sessionId` | The session that made the call |
+| `turnIndex` | `state.move_count` *before* the move (so it can be joined to the log) |
+| `timestamp` | Server-side milliseconds since epoch |
+| `schemaTier` | `server-harvest-v1` |
+| `outcome` | `success` (failures raise, no record is emitted) |
+| `agentId` / `model` / `provider` / `appCommit` | From the `new_game` call |
+| `drawCount`, `seed`, `infoLevel` | Session configuration |
+| `prompt.legalMoves` | The full legal-action list the agent chose from |
+| `prompt.observation` | The information-level-correct board view |
+| `decision.moveIndex` | What the agent picked |
+| `decision.chosenKind`, `chosenDescribe` | The move at that index |
+| `decision.confidence`, `reasoning`, `boardAnalysis`, `alternativeMoveIndex` | Agent-supplied via `decision_meta` |
+| `thinkingText` | Agent-supplied via `decision_meta` (top-level, like the ingest schema) |
+
+Compared to the external collection harness, the server-side harvest closes
+several open data-quality issues by construction:
+
+- **Deck seed / `gameId`** -- always present (registry-assigned session_id, log carries the seed).
+- **Auto-played moves untagged** -- not applicable; every move is an explicit `play_move` call.
+- **Mixed info modes** -- `infoLevel` is stamped on every record from the session's `ObservationConfig`.
+
+Agent identity (`model`, `provider`, `app_commit`) is the one thing the server
+cannot infer -- the agent must declare it once via `new_game`, and the server
+stamps every subsequent decision with the same values.
+
 ## The play loop
 
-An agent plays by repeating three steps:
+An agent plays by repeating three steps per session:
 
 1. **Observe** -- read the observation (foundations, tableau, stock, waste).
 2. **Choose** -- pick a `move_index` from `legal_moves`.
-3. **Act** -- call `play_move`; the response includes the new observation.
+3. **Act** -- call `play_move(session_id, move_index, decision_meta=...)`; the
+   response includes the new observation and the harvested `decision_id`.
 
 Each legal action has a `kind`:
 

--- a/solitaire_analytics/__init__.py
+++ b/solitaire_analytics/__init__.py
@@ -18,6 +18,16 @@ from solitaire_analytics.game import (
     ObservationConfig,
     deal_klondike,
 )
+from solitaire_analytics.harvest import (
+    DecisionHarvest,
+    DecisionRecord,
+    build_decision_record,
+)
+from solitaire_analytics.session_registry import (
+    SessionEntry,
+    SessionRegistry,
+    SessionRegistryError,
+)
 
 __all__ = [
     "Card",
@@ -36,4 +46,10 @@ __all__ = [
     "GameSession",
     "ObservationConfig",
     "deal_klondike",
+    "DecisionHarvest",
+    "DecisionRecord",
+    "build_decision_record",
+    "SessionEntry",
+    "SessionRegistry",
+    "SessionRegistryError",
 ]

--- a/solitaire_analytics/harvest.py
+++ b/solitaire_analytics/harvest.py
@@ -1,0 +1,182 @@
+"""Per-decision harvest emitter for AI-played Solitaire games.
+
+When every move on the MCP server is made by an AI agent (as in the Gemma 4 E2B
+distillation pipeline), the server itself becomes the authoritative source of
+training data. This module captures one structured :class:`DecisionRecord` per
+``play_move`` call -- the (board observation, legal-move list, chosen index,
+agent reasoning) tuple needed to fine-tune a student model.
+
+The on-disk format is JSON Lines (one decision per line) at the path given by
+the ``SOLITAIRE_MCP_HARVEST_FILE`` environment variable. Records are shaped to
+align with the fields ``scripts/ingest_exports.py`` derives from the external
+collection harness (``id``, ``sessionId``, ``turnIndex``, ``model``,
+``provider``, ``appCommit``, plus the parsed ``decision`` and ``prompt`` blocks)
+so the ingest pipeline can pick them up with minimal adaptation.
+"""
+
+import json
+import logging
+import os
+import threading
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+#: Environment variable naming the JSON Lines harvest file.
+ENV_HARVEST_FILE = "SOLITAIRE_MCP_HARVEST_FILE"
+
+#: Schema tag for records emitted by this server. Bump when fields change.
+HARVEST_SCHEMA = "server-harvest-v1"
+
+
+@dataclass
+class DecisionRecord:
+    """One agent decision, harvest-ready.
+
+    Mirrors the per-interaction shape consumed by ``scripts/ingest_exports.py``
+    so the JSONL output drops straight into ``data/raw/`` for distillation.
+
+    Attributes mirror the ingest schema names (camelCase) where they overlap
+    so downstream tooling does not have to translate field names.
+    """
+
+    id: str
+    sessionId: str
+    turnIndex: int
+    timestamp: int
+    schemaTier: str
+    outcome: str
+    agentId: Optional[str]
+    model: Optional[str]
+    provider: Optional[str]
+    appCommit: Optional[str]
+    drawCount: int
+    seed: Optional[int]
+    infoLevel: Dict[str, Any]
+    prompt: Dict[str, Any]
+    decision: Dict[str, Any]
+    thinkingText: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class DecisionHarvest:
+    """Records per-move decisions for offline distillation training.
+
+    Each :meth:`record` call appends one JSON Lines row to the configured
+    harvest file (and keeps an in-memory copy for tests and ``summary()``).
+    Writes are serialised with a lock so concurrent sessions cannot interleave
+    a single record's bytes on disk.
+    """
+
+    def __init__(
+        self,
+        harvest_file: Optional[str] = None,
+        logger: Optional[logging.Logger] = None,
+    ):
+        """Create a harvest emitter.
+
+        Args:
+            harvest_file: Optional JSONL destination. Parent directories are
+                created. ``None`` keeps records in memory only.
+            logger: Logger for diagnostic info (defaults to ``solitaire.harvest``).
+        """
+        self.harvest_file = harvest_file
+        self.logger = logger or logging.getLogger("solitaire.harvest")
+        self.records: List[Dict[str, Any]] = []
+        self._write_lock = threading.Lock()
+        if self.harvest_file:
+            Path(self.harvest_file).parent.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def from_env(cls) -> "DecisionHarvest":
+        """Create a harvest emitter, reading the destination from the env."""
+        return cls(harvest_file=os.environ.get(ENV_HARVEST_FILE) or None)
+
+    def record(self, record: DecisionRecord) -> Dict[str, Any]:
+        """Persist one decision and return the stored dict."""
+        row = record.to_dict()
+        line = json.dumps(row, default=str)
+        with self._write_lock:
+            self.records.append(row)
+            if self.harvest_file:
+                with open(self.harvest_file, "a") as handle:
+                    handle.write(line + "\n")
+        return row
+
+    def summary(self) -> Dict[str, Any]:
+        """Return aggregate stats over all harvested decisions this session."""
+        by_session: Dict[str, int] = {}
+        by_model: Dict[str, int] = {}
+        for row in self.records:
+            sid = row.get("sessionId") or "(none)"
+            by_session[sid] = by_session.get(sid, 0) + 1
+            mdl = row.get("model") or "(none)"
+            by_model[mdl] = by_model.get(mdl, 0) + 1
+        return {
+            "total_decisions": len(self.records),
+            "decisions_by_session": by_session,
+            "decisions_by_model": by_model,
+            "harvest_file": self.harvest_file,
+        }
+
+
+def build_decision_record(
+    *,
+    session_id: str,
+    turn_index: int,
+    legal_actions_snapshot: List[Dict[str, Any]],
+    chosen_index: int,
+    chosen_kind: str,
+    chosen_description: str,
+    observation: Dict[str, Any],
+    draw_count: int,
+    seed: Optional[int],
+    info_level: Dict[str, Any],
+    agent_id: Optional[str],
+    model: Optional[str],
+    provider: Optional[str],
+    app_commit: Optional[str],
+    decision_meta: Optional[Dict[str, Any]] = None,
+) -> DecisionRecord:
+    """Assemble a :class:`DecisionRecord` from the pre-move snapshot.
+
+    ``decision_meta`` carries optional agent-supplied fields (``confidence``,
+    ``reasoning``, ``boardAnalysis``, ``alternativeMoveIndex``, ``thinkingText``);
+    unknown keys are passed through under ``decision`` unchanged.
+    """
+    meta = dict(decision_meta or {})
+    thinking_text = meta.pop("thinkingText", None)
+    decision_block: Dict[str, Any] = {
+        "moveIndex": chosen_index,
+        "chosenKind": chosen_kind,
+        "chosenDescribe": chosen_description,
+    }
+    decision_block.update(meta)
+
+    prompt_block: Dict[str, Any] = {
+        "legalMoves": legal_actions_snapshot,
+        "observation": observation,
+    }
+
+    return DecisionRecord(
+        id=uuid.uuid4().hex,
+        sessionId=session_id,
+        turnIndex=turn_index,
+        timestamp=int(datetime.now(timezone.utc).timestamp() * 1000),
+        schemaTier=HARVEST_SCHEMA,
+        outcome="success",
+        agentId=agent_id,
+        model=model,
+        provider=provider,
+        appCommit=app_commit,
+        drawCount=draw_count,
+        seed=seed,
+        infoLevel=info_level,
+        prompt=prompt_block,
+        decision=decision_block,
+        thinkingText=thinking_text,
+    )

--- a/solitaire_analytics/mcp_server.py
+++ b/solitaire_analytics/mcp_server.py
@@ -1,11 +1,15 @@
 """MCP server exposing Solitaire as a tool-driven game for agentic AI players.
 
-This server lets an MCP-capable agent play Klondike Solitaire move by move.
-The key feature is a configurable *information level*: when starting a game you
-choose how much the agent is allowed to see -- the identity of face-down
-tableau cards, the contents of the stock, and the history of previously drawn
-(waste) cards. This makes it easy to study agent play under realistic
-imperfect information versus perfect information.
+Each connected agent plays its own concurrent game: ``new_game`` returns a
+``session_id`` and every subsequent tool call passes it back. Per-session locks
+keep moves within one game serial while allowing different sessions to make
+progress in parallel.
+
+When every move is made by an AI (the Gemma 4 E2B distillation use case), the
+server doubles as the training-data source: each ``play_move`` emits a
+:class:`~solitaire_analytics.harvest.DecisionRecord` to the JSONL file given by
+``SOLITAIRE_MCP_HARVEST_FILE`` -- carrying the seed, observation, full legal
+move list, chosen index, agent identity, and any agent-supplied reasoning.
 
 Run it over stdio::
 
@@ -23,26 +27,23 @@ from typing import Any, Dict, List, Optional
 from mcp.server.fastmcp import FastMCP
 
 from solitaire_analytics.game import GameSession, ObservationConfig
+from solitaire_analytics.harvest import DecisionHarvest, build_decision_record
 from solitaire_analytics.models.move import MoveType
 from solitaire_analytics.server_analytics import ServerAnalyticsLog
+from solitaire_analytics.session_registry import SessionRegistry
 from solitaire_analytics.strategies import get_strategy
 
 mcp = FastMCP("solitaire-analytics")
 
-# A single active game per server process. new_game() replaces it.
-_session: Optional[GameSession] = None
-
-# Server-side analytics: a cross-game event stream for detailed analysis.
-# Set SOLITAIRE_MCP_LOG_FILE to also append events to a JSON Lines file.
+#: Global multi-session state. The MCP server process owns one of each.
+_registry = SessionRegistry()
 _analytics = ServerAnalyticsLog.from_env()
-_game_seq = 0
-_current_game_id: Optional[str] = None
+_harvest = DecisionHarvest.from_env()
 
 
-def _require_session() -> GameSession:
-    if _session is None:
-        raise ValueError("No game in progress. Call new_game first.")
-    return _session
+def _get_entry(session_id: str):
+    """Look up the registry entry or raise a tool-friendly error."""
+    return _registry.get(session_id)
 
 
 @mcp.tool()
@@ -53,230 +54,335 @@ def new_game(
     stock: str = "count",
     waste: str = "full",
     include_legal_moves: bool = True,
+    agent_id: Optional[str] = None,
+    model: Optional[str] = None,
+    provider: Optional[str] = None,
+    app_commit: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Deal a fresh Klondike Solitaire game and return the first observation.
+    """Deal a fresh Klondike game for this caller and return the first observation.
 
-    The information-level arguments decide what the agent player may see:
+    Multiple agents may keep concurrent games open; each new_game call mints a
+    new ``session_id`` you must pass to every other tool. Agent-identity fields
+    (``agent_id``, ``model``, ``provider``, ``app_commit``) are stamped onto
+    every harvested decision record for downstream training analysis.
 
     Args:
         seed: Optional RNG seed. The same seed always deals the same game.
         draw_count: Cards moved from stock to waste per draw (1 or 3).
         face_down: Visibility of face-down tableau cards -- "count" (only how
-            many are hidden, as a human sees) or "revealed" (their identities,
-            i.e. perfect information).
+            many are hidden) or "revealed" (their identities; perfect info).
         stock: Visibility of the stock pile -- "hidden", "count", or "revealed".
-        waste: Visibility of previously drawn cards -- "top" (only the playable
-            top card) or "full" (the entire drawn pile).
+        waste: Visibility of previously drawn cards -- "top" or "full".
         include_legal_moves: Whether observations embed the legal-move list.
+        agent_id: Optional caller identifier (e.g. an LLM agent name).
+        model: Model name powering the agent (e.g. ``"gemma-4-31b-it"``).
+        provider: Model provider (e.g. ``"gemini"``).
+        app_commit: Caller commit hash for reproducibility.
 
     Returns:
-        The initial observation of the dealt game.
+        ``{"session_id", "observation", "agent": {...}}``.
     """
-    global _session, _game_seq, _current_game_id
-
-    # Record any unfinished prior game as abandoned before replacing it.
-    if _session is not None and _current_game_id is not None:
-        if not (_session.is_won() or _session.is_stuck()):
-            _analytics.record(
-                "game_abandoned",
-                game_id=_current_game_id,
-                move_count=_session.state.move_count,
-                score=_session.state.score,
-            )
-
     config = ObservationConfig(
         face_down=face_down,
         stock=stock,
         waste=waste,
         include_legal_moves=include_legal_moves,
     )
-    _session = GameSession.new_game(
+    session = GameSession.new_game(
         seed=seed, draw_count=draw_count, observation_config=config
     )
-    _game_seq += 1
-    _current_game_id = f"game-{_game_seq}"
+    entry = _registry.create(
+        session,
+        agent_id=agent_id,
+        model=model,
+        provider=provider,
+        app_commit=app_commit,
+    )
     _analytics.record(
         "game_started",
-        game_id=_current_game_id,
+        session_id=entry.session_id,
+        agent_id=agent_id,
+        model=model,
+        provider=provider,
         seed=seed,
         draw_count=draw_count,
         info_level=config.to_dict(),
     )
-    return _session.observation()
+    return {
+        "session_id": entry.session_id,
+        "agent": {
+            "agent_id": entry.agent_id,
+            "model": entry.model,
+            "provider": entry.provider,
+            "app_commit": entry.app_commit,
+        },
+        "observation": session.observation(),
+    }
 
 
 @mcp.tool()
-def get_observation() -> Dict[str, Any]:
-    """Return the current game observation at the configured information level."""
-    return _require_session().observation()
+def list_sessions() -> List[Dict[str, Any]]:
+    """Return summaries of every active session on this server."""
+    return _registry.list()
 
 
 @mcp.tool()
-def get_legal_moves() -> List[Dict[str, Any]]:
-    """Return the legal actions, each with a stable index to pass to play_move."""
-    return [action.to_dict() for action in _require_session().legal_actions()]
+def end_session(session_id: str) -> Dict[str, Any]:
+    """Close a session and free its registry slot.
+
+    Records a ``game_abandoned`` analytics event if the game was unfinished.
+    """
+    entry = _registry.get(session_id)
+    with entry.lock:
+        session = entry.session
+        if not (session.is_won() or session.is_stuck()):
+            _analytics.record(
+                "game_abandoned",
+                session_id=entry.session_id,
+                move_count=session.state.move_count,
+                score=session.state.score,
+            )
+        _registry.end(session_id)
+        return {
+            "ended": True,
+            "session_id": entry.session_id,
+            "move_count": session.state.move_count,
+            "score": session.state.score,
+            "won": session.is_won(),
+            "stuck": session.is_stuck(),
+        }
 
 
 @mcp.tool()
-def play_move(move_index: int) -> Dict[str, Any]:
-    """Apply the legal action at the given index and return the new state.
+def get_observation(session_id: str) -> Dict[str, Any]:
+    """Return the current observation for ``session_id``."""
+    entry = _get_entry(session_id)
+    with entry.lock:
+        return entry.session.observation()
+
+
+@mcp.tool()
+def get_legal_moves(session_id: str) -> List[Dict[str, Any]]:
+    """Return ``session_id``'s legal actions, each with a stable index."""
+    entry = _get_entry(session_id)
+    with entry.lock:
+        return [action.to_dict() for action in entry.session.legal_actions()]
+
+
+@mcp.tool()
+def play_move(
+    session_id: str,
+    move_index: int,
+    decision_meta: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Apply the legal action at ``move_index`` and harvest a training record.
 
     Args:
-        move_index: Index from get_legal_moves (or the embedded legal_moves).
+        session_id: The session returned by ``new_game``.
+        move_index: Index from ``get_legal_moves`` (or the embedded
+            ``legal_moves`` block).
+        decision_meta: Optional agent-supplied fields recorded with the
+            decision (e.g. ``{"confidence": 0.92, "reasoning": "...",
+            "boardAnalysis": "...", "alternativeMoveIndex": 2,
+            "thinkingText": "..."}``). Used for distillation training data.
 
     Returns:
-        A dictionary with the applied action, win/stuck flags, and the
-        resulting observation.
+        ``{"applied", "kind", "won", "stuck", "observation", "decision_id"}``.
     """
-    session = _require_session()
-    result = session.apply_action(move_index)
+    entry = _get_entry(session_id)
+    with entry.lock:
+        session = entry.session
 
-    _analytics.record(
-        "move",
-        game_id=_current_game_id,
-        kind=result["kind"],
-        description=result["applied"],
-        score=session.state.score,
-        move_count=session.state.move_count,
-        won=result["won"],
-        stuck=result["stuck"],
-    )
-    if result["won"] or result["stuck"]:
+        # Snapshot the pre-move state for the harvest record. The
+        # legal_actions list and observation here are exactly what the agent
+        # chose from -- capturing them after apply_action would be the *next*
+        # turn's state and useless for training.
+        pre_actions = session.legal_actions()
+        if not 0 <= move_index < len(pre_actions):
+            raise ValueError(
+                f"Invalid move_index {move_index}; "
+                f"{len(pre_actions)} legal action(s) available"
+            )
+        legal_snapshot = [a.to_dict() for a in pre_actions]
+        chosen = pre_actions[move_index]
+        pre_observation = session.observation()
+        turn_index = session.state.move_count
+
+        result = session.apply_action(move_index)
+
+        record = build_decision_record(
+            session_id=entry.session_id,
+            turn_index=turn_index,
+            legal_actions_snapshot=legal_snapshot,
+            chosen_index=move_index,
+            chosen_kind=chosen.kind,
+            chosen_description=chosen.description,
+            observation=pre_observation,
+            draw_count=session.draw_count,
+            seed=session.seed,
+            info_level=session.observation_config.to_dict(),
+            agent_id=entry.agent_id,
+            model=entry.model,
+            provider=entry.provider,
+            app_commit=entry.app_commit,
+            decision_meta=decision_meta,
+        )
+        _harvest.record(record)
+
         _analytics.record(
-            "game_ended",
-            game_id=_current_game_id,
-            result="won" if result["won"] else "stuck",
+            "move",
+            session_id=entry.session_id,
+            kind=result["kind"],
+            description=result["applied"],
             score=session.state.score,
             move_count=session.state.move_count,
-            redeal_count=session.redeal_count,
+            won=result["won"],
+            stuck=result["stuck"],
         )
+        if result["won"] or result["stuck"]:
+            _analytics.record(
+                "game_ended",
+                session_id=entry.session_id,
+                result="won" if result["won"] else "stuck",
+                score=session.state.score,
+                move_count=session.state.move_count,
+                redeal_count=session.redeal_count,
+            )
 
-    result["observation"] = session.observation()
-    return result
+        result["observation"] = session.observation()
+        result["decision_id"] = record.id
+        return result
 
 
 @mcp.tool()
 def set_information_level(
+    session_id: str,
     face_down: str = "count",
     stock: str = "count",
     waste: str = "full",
     include_legal_moves: bool = True,
 ) -> Dict[str, Any]:
-    """Change the information level revealed to the agent for the current game.
-
-    Args:
-        face_down: "count" or "revealed".
-        stock: "hidden", "count", or "revealed".
-        waste: "top" or "full".
-        include_legal_moves: Whether observations embed the legal-move list.
-
-    Returns:
-        A fresh observation at the new information level.
-    """
-    session = _require_session()
-    session.observation_config = ObservationConfig(
-        face_down=face_down,
-        stock=stock,
-        waste=waste,
-        include_legal_moves=include_legal_moves,
-    )
-    return session.observation()
+    """Change ``session_id``'s information level and return a fresh observation."""
+    entry = _get_entry(session_id)
+    with entry.lock:
+        entry.session.observation_config = ObservationConfig(
+            face_down=face_down,
+            stock=stock,
+            waste=waste,
+            include_legal_moves=include_legal_moves,
+        )
+        return entry.session.observation()
 
 
 @mcp.tool()
-def render_board() -> str:
-    """Return a compact, human-readable text rendering of the current board."""
-    return _require_session().render()
+def render_board(session_id: str) -> str:
+    """Return a compact, human-readable text rendering of the board."""
+    entry = _get_entry(session_id)
+    with entry.lock:
+        return entry.session.render()
 
 
 @mcp.tool()
-def game_status() -> Dict[str, Any]:
-    """Return a short status summary: won, stuck, score, and move/redeal counts."""
-    session = _require_session()
-    return {
-        "won": session.is_won(),
-        "stuck": session.is_stuck(),
-        "score": session.state.score,
-        "move_count": session.state.move_count,
-        "redeal_count": session.redeal_count,
-        "draw_count": session.draw_count,
-        "legal_move_count": len(session.legal_actions()),
-    }
+def game_status(session_id: str) -> Dict[str, Any]:
+    """Return a short status: won, stuck, score, move and redeal counts."""
+    entry = _get_entry(session_id)
+    with entry.lock:
+        session = entry.session
+        return {
+            "session_id": entry.session_id,
+            "won": session.is_won(),
+            "stuck": session.is_stuck(),
+            "score": session.state.score,
+            "move_count": session.state.move_count,
+            "redeal_count": session.redeal_count,
+            "draw_count": session.draw_count,
+            "legal_move_count": len(session.legal_actions()),
+        }
 
 
 @mcp.tool()
-def get_game_log() -> Dict[str, Any]:
-    """Return the full session log of the current game.
-
-    The log captures the seed, the dealt starting deck and game state, every
-    action taken with its resulting state, and the final result -- enough to
-    reproduce and audit the game.
-    """
-    return _require_session().get_log()
+def get_game_log(session_id: str) -> Dict[str, Any]:
+    """Return the full per-game session log (seed, initial state, every action)."""
+    entry = _get_entry(session_id)
+    with entry.lock:
+        return entry.session.get_log()
 
 
 @mcp.tool()
-def save_game_log(path: str) -> Dict[str, Any]:
-    """Write the current game's session log to a JSON file.
-
-    Args:
-        path: Destination file path.
-
-    Returns:
-        A confirmation with the path and number of logged actions.
-    """
-    session = _require_session()
-    session.save_log(path)
-    return {"saved": True, "path": path, "actions_logged": len(session.get_log()["actions"])}
+def save_game_log(session_id: str, path: str) -> Dict[str, Any]:
+    """Write ``session_id``'s log to a JSON file."""
+    entry = _get_entry(session_id)
+    with entry.lock:
+        entry.session.save_log(path)
+        return {
+            "saved": True,
+            "session_id": entry.session_id,
+            "path": path,
+            "actions_logged": len(entry.session.get_log()["actions"]),
+        }
 
 
 @mcp.tool()
 def get_server_analytics() -> Dict[str, Any]:
     """Return aggregate analytics across every game played this server session.
 
-    Includes games started/completed/won/stuck/abandoned, win rate, the count
-    of logged actions broken down by kind, and average game length. Set the
-    SOLITAIRE_MCP_LOG_FILE environment variable to also persist the raw event
-    stream to a JSON Lines file for offline analysis.
+    Set ``SOLITAIRE_MCP_LOG_FILE`` to also persist the raw event stream as a
+    JSON Lines file, and ``SOLITAIRE_MCP_HARVEST_FILE`` to capture one decision
+    record per move for distillation training.
     """
-    return _analytics.summary()
+    summary = _analytics.summary()
+    summary["harvest"] = _harvest.summary()
+    summary["active_sessions"] = len(_registry)
+    return summary
 
 
 @mcp.tool()
-def suggest_move() -> Dict[str, Any]:
-    """Suggest a reasonable move using the built-in greedy strategy (a hint).
+def suggest_move(session_id: str) -> Dict[str, Any]:
+    """Suggest a reasonable move using the built-in greedy strategy (a hint)."""
+    entry = _get_entry(session_id)
+    with entry.lock:
+        session = entry.session
+        actions = session.legal_actions()
+        if not actions:
+            return {"suggestion": None, "reason": "No legal moves; the game is over."}
 
-    Returns:
-        The suggested action's index and description, or a note if the only
-        option is to recycle the waste or the game is over.
-    """
-    session = _require_session()
-    actions = session.legal_actions()
-    if not actions:
-        return {"suggestion": None, "reason": "No legal moves; the game is over."}
+        suggested = get_strategy("simple").select_best_move(session.state)
+        if suggested is None:
+            recycle = next((a for a in actions if a.kind == "recycle"), None)
+            if recycle is not None:
+                return {
+                    "suggestion": recycle.to_dict(),
+                    "reason": "Recycle the waste pile.",
+                }
+            return {
+                "suggestion": actions[0].to_dict(),
+                "reason": "Fallback to first legal move.",
+            }
 
-    suggested = get_strategy("simple").select_best_move(session.state)
-    if suggested is None:
-        recycle = next((a for a in actions if a.kind == "recycle"), None)
-        if recycle is not None:
-            return {"suggestion": recycle.to_dict(), "reason": "Recycle the waste pile."}
-        return {"suggestion": actions[0].to_dict(), "reason": "Fallback to first legal move."}
+        for action in actions:
+            move = action.move
+            if move is None:
+                continue
+            if move.move_type == MoveType.STOCK_TO_WASTE == suggested.move_type:
+                return {
+                    "suggestion": action.to_dict(),
+                    "reason": "Greedy strategy pick.",
+                }
+            if (
+                move.move_type == suggested.move_type
+                and move.source_pile == suggested.source_pile
+                and move.dest_pile == suggested.dest_pile
+                and move.num_cards == suggested.num_cards
+            ):
+                return {
+                    "suggestion": action.to_dict(),
+                    "reason": "Greedy strategy pick.",
+                }
 
-    for action in actions:
-        move = action.move
-        if move is None:
-            continue
-        if move.move_type == MoveType.STOCK_TO_WASTE == suggested.move_type:
-            return {"suggestion": action.to_dict(), "reason": "Greedy strategy pick."}
-        if (
-            move.move_type == suggested.move_type
-            and move.source_pile == suggested.source_pile
-            and move.dest_pile == suggested.dest_pile
-            and move.num_cards == suggested.num_cards
-        ):
-            return {"suggestion": action.to_dict(), "reason": "Greedy strategy pick."}
-
-    return {"suggestion": actions[0].to_dict(), "reason": "Fallback to first legal move."}
+        return {
+            "suggestion": actions[0].to_dict(),
+            "reason": "Fallback to first legal move.",
+        }
 
 
 def main() -> None:

--- a/solitaire_analytics/session_registry.py
+++ b/solitaire_analytics/session_registry.py
@@ -1,0 +1,157 @@
+"""In-process registry of concurrent Solitaire game sessions.
+
+The MCP server used to hold a single global :class:`GameSession`; this registry
+lets many agents each play their own game over the same server process. Every
+session is identified by a server-issued ``session_id`` (UUID4) and carries
+optional agent-supplied metadata (``agent_id``, ``model``, ``provider``,
+``app_commit``) that the harvest emitter stamps onto each decision record.
+
+Each session is guarded by its own :class:`threading.RLock` so two MCP tool
+calls for different sessions can run concurrently without serialising on a
+single global lock; calls for the *same* session still serialise so a moves
+sequence within a game stays consistent. Use :meth:`SessionRegistry.lock` as a
+context manager whenever you read or mutate session state from a request
+handler.
+"""
+
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from solitaire_analytics.game import GameSession
+
+
+class SessionRegistryError(RuntimeError):
+    """Raised for session-registry problems (full, missing, duplicate)."""
+
+
+@dataclass
+class SessionEntry:
+    """A single registered session and its agent-declared metadata.
+
+    Attributes:
+        session_id: Server-issued opaque identifier the agent passes back.
+        session: The wrapped :class:`GameSession`.
+        agent_id: Optional caller-supplied agent identifier.
+        model: Optional model name used by the agent (e.g. ``"gemma-4-31b-it"``).
+        provider: Optional model provider (e.g. ``"gemini"``, ``"openai"``).
+        app_commit: Optional commit hash of the caller, for reproducibility.
+        created_at: UTC creation timestamp.
+        lock: Per-session reentrant lock; held during any state-mutating call.
+    """
+
+    session_id: str
+    session: GameSession
+    agent_id: Optional[str] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+    app_commit: Optional[str] = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    lock: threading.RLock = field(default_factory=threading.RLock)
+
+    def info(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable summary suitable for ``list_sessions``."""
+        return {
+            "session_id": self.session_id,
+            "agent_id": self.agent_id,
+            "model": self.model,
+            "provider": self.provider,
+            "app_commit": self.app_commit,
+            "created_at": self.created_at.isoformat(),
+            "move_count": self.session.state.move_count,
+            "score": self.session.state.score,
+            "won": self.session.is_won(),
+            "stuck": self.session.is_stuck(),
+            "draw_count": self.session.draw_count,
+            "seed": self.session.seed,
+        }
+
+
+class SessionRegistry:
+    """Thread-safe registry of concurrent :class:`GameSession` instances."""
+
+    def __init__(self, max_sessions: int = 100):
+        """Create a registry.
+
+        Args:
+            max_sessions: Hard cap on simultaneously open sessions. Reached
+                when ``create()`` would push the count over the cap; callers
+                must explicitly ``end()`` finished games to free a slot.
+        """
+        if max_sessions < 1:
+            raise ValueError(f"max_sessions must be >= 1, got {max_sessions}")
+        self.max_sessions = int(max_sessions)
+        self._entries: Dict[str, SessionEntry] = {}
+        self._registry_lock = threading.Lock()
+
+    def create(
+        self,
+        session: GameSession,
+        agent_id: Optional[str] = None,
+        model: Optional[str] = None,
+        provider: Optional[str] = None,
+        app_commit: Optional[str] = None,
+    ) -> SessionEntry:
+        """Register a new session and return its entry (with the ``session_id``).
+
+        Raises:
+            SessionRegistryError: If the registry is at ``max_sessions``.
+        """
+        with self._registry_lock:
+            if len(self._entries) >= self.max_sessions:
+                raise SessionRegistryError(
+                    f"Session registry full ({self.max_sessions} active); "
+                    "end an existing session before starting a new one."
+                )
+            session_id = uuid.uuid4().hex
+            entry = SessionEntry(
+                session_id=session_id,
+                session=session,
+                agent_id=agent_id,
+                model=model,
+                provider=provider,
+                app_commit=app_commit,
+            )
+            self._entries[session_id] = entry
+            return entry
+
+    def get(self, session_id: str) -> SessionEntry:
+        """Return the entry for ``session_id``.
+
+        Raises:
+            SessionRegistryError: If no such session exists.
+        """
+        with self._registry_lock:
+            entry = self._entries.get(session_id)
+        if entry is None:
+            raise SessionRegistryError(
+                f"Unknown session_id {session_id!r}; "
+                "call new_game to start a session."
+            )
+        return entry
+
+    def end(self, session_id: str) -> SessionEntry:
+        """Remove and return the session entry. Raises if missing."""
+        with self._registry_lock:
+            entry = self._entries.pop(session_id, None)
+        if entry is None:
+            raise SessionRegistryError(
+                f"Unknown session_id {session_id!r}; cannot end."
+            )
+        return entry
+
+    def list(self) -> List[Dict[str, Any]]:
+        """Return a snapshot of all active sessions as summary dicts."""
+        with self._registry_lock:
+            entries = list(self._entries.values())
+        return [entry.info() for entry in entries]
+
+    def __len__(self) -> int:
+        with self._registry_lock:
+            return len(self._entries)
+
+    def __contains__(self, session_id: str) -> bool:
+        with self._registry_lock:
+            return session_id in self._entries

--- a/tests/test_harvest.py
+++ b/tests/test_harvest.py
@@ -1,0 +1,148 @@
+"""Tests for the per-decision harvest emitter."""
+
+import json
+import os
+from unittest.mock import patch
+
+import pytest
+
+from solitaire_analytics.harvest import (
+    ENV_HARVEST_FILE,
+    HARVEST_SCHEMA,
+    DecisionHarvest,
+    DecisionRecord,
+    build_decision_record,
+)
+
+
+def _sample_record(session_id: str = "s1", turn_index: int = 0) -> DecisionRecord:
+    return build_decision_record(
+        session_id=session_id,
+        turn_index=turn_index,
+        legal_actions_snapshot=[
+            {"index": 0, "kind": "move", "description": "AS->2H"},
+            {"index": 1, "kind": "draw", "description": "Draw 1"},
+        ],
+        chosen_index=0,
+        chosen_kind="move",
+        chosen_description="AS->2H",
+        observation={"tableau": []},
+        draw_count=1,
+        seed=42,
+        info_level={"face_down": "count"},
+        agent_id="alice",
+        model="gemma-4-31b-it",
+        provider="gemini",
+        app_commit="abc1234",
+        decision_meta={
+            "confidence": 0.9,
+            "reasoning": "expose face-down",
+            "thinkingText": "thinking...",
+            "alternativeMoveIndex": 1,
+        },
+    )
+
+
+@pytest.mark.unit
+class TestBuildDecisionRecord:
+    """build_decision_record packs ingest-shaped rows."""
+
+    def test_record_has_required_ingest_fields(self):
+        record = _sample_record().to_dict()
+        for field in (
+            "id",
+            "sessionId",
+            "turnIndex",
+            "timestamp",
+            "schemaTier",
+            "outcome",
+            "agentId",
+            "model",
+            "provider",
+            "appCommit",
+            "drawCount",
+            "seed",
+            "infoLevel",
+            "prompt",
+            "decision",
+            "thinkingText",
+        ):
+            assert field in record, f"missing {field}"
+
+    def test_decision_block_captures_chosen_move(self):
+        record = _sample_record().to_dict()
+        assert record["decision"]["moveIndex"] == 0
+        assert record["decision"]["chosenKind"] == "move"
+        assert record["decision"]["chosenDescribe"] == "AS->2H"
+        assert record["decision"]["confidence"] == 0.9
+        assert record["decision"]["reasoning"] == "expose face-down"
+        assert record["decision"]["alternativeMoveIndex"] == 1
+
+    def test_prompt_block_carries_legal_moves(self):
+        record = _sample_record().to_dict()
+        assert len(record["prompt"]["legalMoves"]) == 2
+        assert record["prompt"]["legalMoves"][0]["description"] == "AS->2H"
+
+    def test_thinking_text_lifted_out_of_decision_meta(self):
+        record = _sample_record().to_dict()
+        # thinkingText is a top-level field in the ingest schema, not under
+        # "decision" -- the builder pops it from decision_meta accordingly.
+        assert record["thinkingText"] == "thinking..."
+        assert "thinkingText" not in record["decision"]
+
+    def test_schema_tier_marked_for_server_harvest(self):
+        record = _sample_record().to_dict()
+        assert record["schemaTier"] == HARVEST_SCHEMA
+
+    def test_agent_metadata_passed_through(self):
+        record = _sample_record().to_dict()
+        assert record["agentId"] == "alice"
+        assert record["model"] == "gemma-4-31b-it"
+        assert record["provider"] == "gemini"
+        assert record["appCommit"] == "abc1234"
+
+
+@pytest.mark.unit
+class TestDecisionHarvest:
+    """DecisionHarvest writes JSONL and aggregates summaries."""
+
+    def test_record_kept_in_memory(self):
+        harvest = DecisionHarvest()
+        harvest.record(_sample_record())
+        assert len(harvest.records) == 1
+        assert harvest.records[0]["sessionId"] == "s1"
+
+    def test_record_writes_jsonl_line(self, tmp_path):
+        path = tmp_path / "events" / "harvest.jsonl"
+        harvest = DecisionHarvest(harvest_file=str(path))
+        harvest.record(_sample_record(turn_index=0))
+        harvest.record(_sample_record(turn_index=1))
+
+        lines = path.read_text().strip().splitlines()
+        assert len(lines) == 2
+        row = json.loads(lines[0])
+        assert row["sessionId"] == "s1"
+        assert row["turnIndex"] == 0
+        assert row["schemaTier"] == HARVEST_SCHEMA
+
+    def test_summary_breaks_down_by_session_and_model(self):
+        harvest = DecisionHarvest()
+        harvest.record(_sample_record(session_id="s1"))
+        harvest.record(_sample_record(session_id="s1", turn_index=1))
+        harvest.record(_sample_record(session_id="s2"))
+
+        summary = harvest.summary()
+        assert summary["total_decisions"] == 3
+        assert summary["decisions_by_session"] == {"s1": 2, "s2": 1}
+        assert summary["decisions_by_model"] == {"gemma-4-31b-it": 3}
+
+    def test_from_env_reads_path(self, tmp_path):
+        path = tmp_path / "from_env.jsonl"
+        with patch.dict(os.environ, {ENV_HARVEST_FILE: str(path)}):
+            harvest = DecisionHarvest.from_env()
+        assert harvest.harvest_file == str(path)
+
+    def test_from_env_with_no_var_keeps_memory_only(self):
+        with patch.dict(os.environ, {}, clear=True):
+            harvest = DecisionHarvest.from_env()
+        assert harvest.harvest_file is None

--- a/tests/test_mcp_integration.py
+++ b/tests/test_mcp_integration.py
@@ -1,0 +1,156 @@
+"""End-to-end integration tests: full playthroughs via the multi-session MCP API.
+
+Drives 2-3 concurrent sessions through the actual MCP tool functions until
+each game finishes or hits a move cap, asserting:
+
+* sessions stay isolated (one game's moves don't leak into another's log),
+* the harvest emits exactly one record per applied move,
+* each harvested record reconstructs the chosen action correctly,
+* end_session frees its slot and survives the cap,
+* list_sessions/get_server_analytics reflect the live state.
+"""
+
+import json
+
+import pytest
+
+from solitaire_analytics import mcp_server as server
+from solitaire_analytics.harvest import DecisionHarvest
+from solitaire_analytics.server_analytics import ServerAnalyticsLog
+from solitaire_analytics.session_registry import SessionRegistry
+
+
+MOVE_CAP = 80  # cap per session so the test stays well under the pytest timeout
+
+
+@pytest.fixture
+def fresh_server(monkeypatch, tmp_path):
+    """Isolated registry/analytics/harvest per test."""
+    harvest_path = tmp_path / "harvest.jsonl"
+    monkeypatch.setattr(server, "_registry", SessionRegistry(max_sessions=10))
+    monkeypatch.setattr(server, "_analytics", ServerAnalyticsLog())
+    monkeypatch.setattr(
+        server, "_harvest", DecisionHarvest(harvest_file=str(harvest_path))
+    )
+    return harvest_path
+
+
+def _greedy_play(session_id: str, cap: int = MOVE_CAP) -> int:
+    """Play a session forward with a trivial 'prefer real moves' agent.
+
+    Returns the number of moves applied. Stops at cap, win, or stuck.
+    """
+    applied = 0
+    for _ in range(cap):
+        status = server.game_status(session_id)
+        if status["won"] or status["stuck"]:
+            break
+        legal = server.get_legal_moves(session_id)
+        # Pick a real tableau/foundation move when one exists; otherwise
+        # draw/recycle. The point is to exercise many code paths, not to win.
+        chosen = next(
+            (a for a in legal if a["kind"] == "move"),
+            legal[0] if legal else None,
+        )
+        if chosen is None:
+            break
+        server.play_move(
+            session_id,
+            chosen["index"],
+            decision_meta={"confidence": 0.9, "reasoning": "greedy"},
+        )
+        applied += 1
+    return applied
+
+
+@pytest.mark.integration
+class TestConcurrentPlaythrough:
+    """Drive multiple sessions to completion through the MCP tool layer."""
+
+    def test_two_sessions_play_independently(self, fresh_server):
+        harvest_path = fresh_server
+        a = server.new_game(seed=11, agent_id="alpha", model="m-alpha")["session_id"]
+        b = server.new_game(seed=22, agent_id="beta", model="m-beta")["session_id"]
+
+        moves_a = _greedy_play(a)
+        moves_b = _greedy_play(b)
+
+        assert moves_a > 0 and moves_b > 0
+
+        # Each session's log only contains its own moves.
+        log_a = server.get_game_log(a)
+        log_b = server.get_game_log(b)
+        assert log_a["seed"] == 11
+        assert log_b["seed"] == 22
+        assert len(log_a["actions"]) == moves_a
+        assert len(log_b["actions"]) == moves_b
+
+        # Harvest captured every applied move, tagged with the right session.
+        lines = harvest_path.read_text().strip().splitlines()
+        records = [json.loads(line) for line in lines]
+        assert len(records) == moves_a + moves_b
+        per_session: dict[str, int] = {}
+        for record in records:
+            per_session[record["sessionId"]] = per_session.get(record["sessionId"], 0) + 1
+        assert per_session[a] == moves_a
+        assert per_session[b] == moves_b
+
+        # Agent identity stayed pinned to the session that started it.
+        for record in records:
+            if record["sessionId"] == a:
+                assert record["agentId"] == "alpha"
+                assert record["model"] == "m-alpha"
+            else:
+                assert record["agentId"] == "beta"
+                assert record["model"] == "m-beta"
+
+    def test_harvest_records_reconstruct_the_chosen_move(self, fresh_server):
+        """Every record's snapshot[moveIndex] must equal the move actually applied."""
+        harvest_path = fresh_server
+        sid = server.new_game(seed=7)["session_id"]
+        _greedy_play(sid, cap=30)
+
+        records = [
+            json.loads(line)
+            for line in harvest_path.read_text().strip().splitlines()
+        ]
+        assert len(records) > 0
+        log_actions = server.get_game_log(sid)["actions"]
+        assert len(records) == len(log_actions)
+
+        for record, logged in zip(records, log_actions):
+            chosen_idx = record["decision"]["moveIndex"]
+            snapshot = record["prompt"]["legalMoves"]
+            assert 0 <= chosen_idx < len(snapshot)
+            # The snapshot's chosen entry describes the move that the session
+            # log says was applied. This catches off-by-one snapshot/apply bugs.
+            assert snapshot[chosen_idx]["description"] == logged["description"]
+
+    def test_end_session_frees_slot_and_records_outcome(self, fresh_server):
+        a = server.new_game(seed=11)["session_id"]
+        b = server.new_game(seed=22)["session_id"]
+
+        _greedy_play(a, cap=20)
+        # End an in-progress game -- expect game_abandoned.
+        server.end_session(a)
+        assert server._registry.__contains__(a) is False
+
+        # Starting a new session should succeed (slot freed); b remains alive.
+        c = server.new_game(seed=33)["session_id"]
+        rows = server.list_sessions()
+        ids = {row["session_id"] for row in rows}
+        assert ids == {b, c}
+
+    def test_server_analytics_reflects_full_run(self, fresh_server):
+        a = server.new_game(seed=11)["session_id"]
+        b = server.new_game(seed=22)["session_id"]
+        moves_a = _greedy_play(a)
+        moves_b = _greedy_play(b)
+
+        summary = server.get_server_analytics()
+        assert summary["active_sessions"] == 2
+        assert summary["games_started"] == 2
+        assert summary["actions_logged"] == moves_a + moves_b
+        # harvest summary echoes the same total
+        assert summary["harvest"]["total_decisions"] == moves_a + moves_b
+        assert set(summary["harvest"]["decisions_by_session"]) == {a, b}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,190 @@
+"""Tests for the multi-session MCP server module.
+
+These exercise the underlying tool functions directly -- we do not spin up
+FastMCP's stdio transport. The MCP server holds module-level singletons
+(registry, analytics, harvest), so each test resets them in a fixture.
+"""
+
+import json
+
+import pytest
+
+from solitaire_analytics import mcp_server as server
+from solitaire_analytics.harvest import DecisionHarvest
+from solitaire_analytics.server_analytics import ServerAnalyticsLog
+from solitaire_analytics.session_registry import (
+    SessionRegistry,
+    SessionRegistryError,
+)
+
+
+@pytest.fixture
+def fresh_server(monkeypatch, tmp_path):
+    """Reset the MCP server's module-level singletons for each test.
+
+    Returns the (registry, analytics, harvest) triple so tests can introspect
+    them. A harvest file is wired up so we can assert on disk output without
+    side-effecting the real environment.
+    """
+    harvest_path = tmp_path / "harvest.jsonl"
+    registry = SessionRegistry(max_sessions=10)
+    analytics = ServerAnalyticsLog()
+    harvest = DecisionHarvest(harvest_file=str(harvest_path))
+    monkeypatch.setattr(server, "_registry", registry)
+    monkeypatch.setattr(server, "_analytics", analytics)
+    monkeypatch.setattr(server, "_harvest", harvest)
+    return registry, analytics, harvest, harvest_path
+
+
+@pytest.mark.unit
+class TestNewGame:
+    """new_game registers a session and returns its identity."""
+
+    def test_returns_session_id_and_observation(self, fresh_server):
+        registry, *_ = fresh_server
+        result = server.new_game(seed=1)
+        assert "session_id" in result
+        assert "observation" in result
+        assert result["session_id"] in registry
+
+    def test_records_agent_metadata(self, fresh_server):
+        registry, *_ = fresh_server
+        result = server.new_game(
+            seed=1,
+            agent_id="alice",
+            model="gemma-4-31b-it",
+            provider="gemini",
+            app_commit="abc",
+        )
+        assert result["agent"]["agent_id"] == "alice"
+        assert result["agent"]["model"] == "gemma-4-31b-it"
+        entry = registry.get(result["session_id"])
+        assert entry.model == "gemma-4-31b-it"
+
+    def test_emits_game_started_event(self, fresh_server):
+        _, analytics, *_ = fresh_server
+        server.new_game(seed=1, model="m")
+        events = [e for e in analytics.events if e["event"] == "game_started"]
+        assert len(events) == 1
+        assert events[0]["model"] == "m"
+        assert "session_id" in events[0]
+
+
+@pytest.mark.unit
+class TestMultiSessionIsolation:
+    """Two sessions on one server stay independent."""
+
+    def test_two_sessions_have_distinct_state(self, fresh_server):
+        a = server.new_game(seed=1)["session_id"]
+        b = server.new_game(seed=2)["session_id"]
+        assert a != b
+
+        # Apply a move in session A only; session B's move_count stays at 0.
+        server.play_move(a, 0)
+        status_a = server.game_status(a)
+        status_b = server.game_status(b)
+        assert status_a["move_count"] >= 1
+        assert status_b["move_count"] == 0
+
+    def test_list_sessions_reflects_live_state(self, fresh_server):
+        a = server.new_game(seed=1)["session_id"]
+        b = server.new_game(seed=2)["session_id"]
+        rows = server.list_sessions()
+        ids = {row["session_id"] for row in rows}
+        assert ids == {a, b}
+
+    def test_unknown_session_raises(self, fresh_server):
+        with pytest.raises(SessionRegistryError):
+            server.play_move("not-a-session", 0)
+
+
+@pytest.mark.unit
+class TestPlayMoveHarvest:
+    """play_move records one DecisionRecord per move."""
+
+    def test_decision_record_emitted(self, fresh_server):
+        _, _, harvest, harvest_path = fresh_server
+        sid = server.new_game(
+            seed=1, agent_id="alice", model="gemma-4-31b-it"
+        )["session_id"]
+        result = server.play_move(
+            sid,
+            0,
+            decision_meta={"confidence": 0.95, "reasoning": "test"},
+        )
+        assert result["decision_id"]
+        assert len(harvest.records) == 1
+        record = harvest.records[0]
+        assert record["sessionId"] == sid
+        assert record["model"] == "gemma-4-31b-it"
+        assert record["decision"]["moveIndex"] == 0
+        assert record["decision"]["confidence"] == 0.95
+        assert record["turnIndex"] == 0  # state.move_count before the move
+
+    def test_decision_record_persisted_to_jsonl(self, fresh_server):
+        _, _, _, harvest_path = fresh_server
+        sid = server.new_game(seed=1)["session_id"]
+        server.play_move(sid, 0)
+        server.play_move(sid, 0)
+        lines = harvest_path.read_text().strip().splitlines()
+        assert len(lines) == 2
+        first = json.loads(lines[0])
+        assert first["sessionId"] == sid
+
+    def test_invalid_move_index_does_not_emit_record(self, fresh_server):
+        _, _, harvest, _ = fresh_server
+        sid = server.new_game(seed=1)["session_id"]
+        with pytest.raises(ValueError):
+            server.play_move(sid, 999)
+        assert harvest.records == []
+
+    def test_legal_moves_snapshot_matches_choice(self, fresh_server):
+        # The harvest record must capture the legal-action list the agent
+        # *saw* at decision time, not the post-move list. Re-checking the
+        # chosen index against the snapshot should yield the same description.
+        _, _, harvest, _ = fresh_server
+        sid = server.new_game(seed=1)["session_id"]
+        legal_before = server.get_legal_moves(sid)
+        chosen_idx = next(i for i, a in enumerate(legal_before) if a["kind"] == "draw")
+        result = server.play_move(sid, chosen_idx)
+
+        record = harvest.records[0]
+        snapshot = record["prompt"]["legalMoves"]
+        assert snapshot == legal_before
+        assert snapshot[chosen_idx]["description"] == result["applied"]
+
+
+@pytest.mark.unit
+class TestEndSession:
+    """end_session frees the slot and tags abandonments."""
+
+    def test_end_removes_from_registry(self, fresh_server):
+        registry, *_ = fresh_server
+        sid = server.new_game(seed=1)["session_id"]
+        server.end_session(sid)
+        assert sid not in registry
+
+    def test_end_unfinished_records_abandoned_event(self, fresh_server):
+        _, analytics, *_ = fresh_server
+        sid = server.new_game(seed=1)["session_id"]
+        server.end_session(sid)
+        abandoned = [e for e in analytics.events if e["event"] == "game_abandoned"]
+        assert len(abandoned) == 1
+        assert abandoned[0]["session_id"] == sid
+
+    def test_end_unknown_raises(self, fresh_server):
+        with pytest.raises(SessionRegistryError):
+            server.end_session("not-a-session")
+
+
+@pytest.mark.unit
+class TestGetServerAnalytics:
+    """get_server_analytics aggregates events + harvest + session count."""
+
+    def test_summary_includes_harvest_and_active_sessions(self, fresh_server):
+        server.new_game(seed=1)
+        server.new_game(seed=2)
+        summary = server.get_server_analytics()
+        assert summary["active_sessions"] == 2
+        assert "harvest" in summary
+        assert summary["games_started"] == 2

--- a/tests/test_session_registry.py
+++ b/tests/test_session_registry.py
@@ -1,0 +1,136 @@
+"""Tests for the multi-session registry."""
+
+import threading
+
+import pytest
+
+from solitaire_analytics.game import GameSession
+from solitaire_analytics.session_registry import (
+    SessionEntry,
+    SessionRegistry,
+    SessionRegistryError,
+)
+
+
+def _make_session(seed: int = 1) -> GameSession:
+    return GameSession.new_game(seed=seed)
+
+
+@pytest.mark.unit
+class TestSessionRegistry:
+    """Unit tests for SessionRegistry create/get/list/end semantics."""
+
+    def test_create_returns_entry_with_unique_id(self):
+        registry = SessionRegistry()
+        a = registry.create(_make_session(1))
+        b = registry.create(_make_session(2))
+        assert isinstance(a, SessionEntry)
+        assert a.session_id != b.session_id
+        assert len(registry) == 2
+
+    def test_get_returns_registered_entry(self):
+        registry = SessionRegistry()
+        entry = registry.create(_make_session(1), agent_id="alice", model="m1")
+        fetched = registry.get(entry.session_id)
+        assert fetched is entry
+        assert fetched.agent_id == "alice"
+        assert fetched.model == "m1"
+
+    def test_get_unknown_raises(self):
+        registry = SessionRegistry()
+        with pytest.raises(SessionRegistryError):
+            registry.get("not-a-session")
+
+    def test_end_removes_entry(self):
+        registry = SessionRegistry()
+        entry = registry.create(_make_session(1))
+        registry.end(entry.session_id)
+        assert entry.session_id not in registry
+        assert len(registry) == 0
+        with pytest.raises(SessionRegistryError):
+            registry.get(entry.session_id)
+
+    def test_end_unknown_raises(self):
+        registry = SessionRegistry()
+        with pytest.raises(SessionRegistryError):
+            registry.end("not-a-session")
+
+    def test_max_sessions_enforced(self):
+        registry = SessionRegistry(max_sessions=2)
+        registry.create(_make_session(1))
+        registry.create(_make_session(2))
+        with pytest.raises(SessionRegistryError):
+            registry.create(_make_session(3))
+
+    def test_max_sessions_after_end_frees_slot(self):
+        registry = SessionRegistry(max_sessions=2)
+        a = registry.create(_make_session(1))
+        registry.create(_make_session(2))
+        registry.end(a.session_id)
+        # Should succeed now that a slot is free.
+        registry.create(_make_session(3))
+        assert len(registry) == 2
+
+    def test_list_returns_summaries_with_metadata(self):
+        registry = SessionRegistry()
+        registry.create(
+            _make_session(1),
+            agent_id="alice",
+            model="m1",
+            provider="gemini",
+            app_commit="abc123",
+        )
+        registry.create(_make_session(2), agent_id="bob")
+
+        rows = registry.list()
+        assert len(rows) == 2
+        agents = {row["agent_id"] for row in rows}
+        assert agents == {"alice", "bob"}
+        alice_row = next(row for row in rows if row["agent_id"] == "alice")
+        assert alice_row["model"] == "m1"
+        assert alice_row["provider"] == "gemini"
+        assert alice_row["app_commit"] == "abc123"
+        assert alice_row["seed"] == 1
+        assert "session_id" in alice_row
+
+    def test_per_session_lock_is_reentrant(self):
+        registry = SessionRegistry()
+        entry = registry.create(_make_session(1))
+        # An RLock can be acquired twice by the same thread; the second acquire
+        # must not deadlock. This guards against accidentally using a plain
+        # Lock, which would hang here.
+        with entry.lock:
+            with entry.lock:
+                assert True
+
+    def test_concurrent_access_to_different_sessions_does_not_serialise(self):
+        # Two threads each hold their own session lock at the same time;
+        # neither blocks the other. This proves the registry uses per-session
+        # locks rather than a single global one.
+        registry = SessionRegistry()
+        a = registry.create(_make_session(1))
+        b = registry.create(_make_session(2))
+
+        both_in_critical = threading.Event()
+        started = threading.Barrier(2)
+
+        def hold(entry, peer_in_critical: threading.Event):
+            with entry.lock:
+                started.wait(timeout=1.0)
+                # Signal we hold our lock and wait briefly for the peer to do
+                # the same. If the registry serialised, this barrier would
+                # never balance.
+                peer_in_critical.wait(timeout=1.0)
+                both_in_critical.set()
+
+        peer_a = threading.Event()
+        peer_b = threading.Event()
+        ta = threading.Thread(target=hold, args=(a, peer_b))
+        tb = threading.Thread(target=hold, args=(b, peer_a))
+        ta.start()
+        tb.start()
+        peer_a.set()
+        peer_b.set()
+        ta.join(timeout=2.0)
+        tb.join(timeout=2.0)
+        assert both_in_critical.is_set()


### PR DESCRIPTION
## Summary

- Lets multiple agents each play their own Klondike game concurrently over a single MCP server process. `new_game` returns a server-issued `session_id`; every per-game tool now takes `session_id` as its first argument.
- `SessionRegistry` keyed by UUID4, capped at 100 simultaneous sessions, with a per-session `threading.RLock` so two agents' tool calls run in parallel while moves within one game stay serial. New tools: `list_sessions`, `end_session`.
- `DecisionHarvest` emits one structured record per `play_move` call to JSONL at `SOLITAIRE_MCP_HARVEST_FILE` — the pre-move legal-move snapshot, full information-level-correct observation, chosen index, and any agent-supplied `decision_meta` (`confidence`, `reasoning`, `boardAnalysis`, `alternativeMoveIndex`, `thinkingText`). Output shape aligns with `scripts/ingest_exports.py` so it drops into `data/raw/` for the E2B distillation pipeline.
- For the harvest use case (AI agents only), the server closes three open data-quality issues from the external collection harness by construction: deck seed always present (registry-issued session id + log carries the seed), info mode unambiguous (`infoLevel` stamped on every record), no auto-played untagged moves (every move is an explicit `play_move`). Agent identity (`agent_id`, `model`, `provider`, `app_commit`) is declared once to `new_game` and stamped onto every record.

## Test plan

- [x] Existing 148 tests still pass
- [x] 10 new unit tests for `SessionRegistry` (create/get/end, max cap, lock isolation across sessions)
- [x] 11 new unit tests for `DecisionHarvest` (record shape, JSONL writes, env wiring, summary)
- [x] 14 new unit tests for the rewritten MCP tools (multi-session isolation, harvest emission, end_session semantics)
- [x] 4 integration tests driving concurrent full playthroughs through the tool layer, asserting per-session log isolation and that every harvested record reconstructs the chosen move against the session log
- [x] End-to-end smoke: 1 game (seed=11, 200 moves) played through the multi-session API; harvest wrote 200 rows, each correctly tagged with `sessionId`, `agentId`, `model`, `seed`, `infoLevel`
- [x] Total: 187 passed, 87% coverage (`harvest.py` 100%, `session_registry.py` 98%)

## Docs

`docs/mcp_server.md` rewritten with sections on the multi-session model, the updated tool surface, and the harvest emitter including the field-by-field mapping to the ingest schema.